### PR TITLE
logrotate.t fail on custom perl

### DIFF
--- a/t/logrotate.t
+++ b/t/logrotate.t
@@ -26,7 +26,7 @@ sub setup :Test(setup) {
 sub logrotate :Tests(4) {
     my $service = Ubic::Service::SimpleDaemon->new({
         name => 'simple1',
-        bin => ['perl', '-e', 'use IO::Handle; use Time::HiRes qw(sleep); STDOUT->autoflush(1); $SIG{HUP} = "IGNORE"; for (1..100) {print "stdout: $_\n"; warn "stderr $_\n"; sleep 0.1;}'],
+        bin => [$^X, '-e', 'use IO::Handle; use Time::HiRes qw(sleep); STDOUT->autoflush(1); $SIG{HUP} = "IGNORE"; for (1..100) {print "stdout: $_\n"; warn "stderr $_\n"; sleep 0.1;}'],
         stdout => 'tfiles/stdout',
         stderr => 'tfiles/stderr',
         ubic_log => 'tfiles/ubic.log',


### PR DESCRIPTION
logrotate.t fail if run installation with custom perl and without installed perl-Time-HiRes package
PERL_DL_NONLAZY=1 /my/perl "-MExtUtils::Command::MM" "-e" "test_harness(0, 'blib/lib', 'blib/arch')" t/logrotate.t
t/logrotate.t .. 1/4 
t/logrotate.t .. Dubious, test returned 4 (wstat 1024, 0x400)
Failed 4/4 subtests
